### PR TITLE
Support GHC 8.4.1

### DIFF
--- a/machinecell.cabal
+++ b/machinecell.cabal
@@ -42,7 +42,7 @@ library
         Control.Arrow.Machine.Misc.Discrete
   other-extensions:    FlexibleInstances, Arrows, RankNTypes, TypeSynonymInstances, MultiParamTypeClasses, GADTs, FlexibleContexts, NoMonomorphismRestriction, RecursiveDo
   ghc-options: -Wall
-  build-depends:       base >=4.7.0.0 && <5.0, mtl >=2.2.1 && <3, free >=4.12.3 && <5, semigroups >=0.18.1 && <1, profunctors >=5.2 && <6, transformers >=0.5.0.0 && <1
+  build-depends:       base >=4.8 && <5.0, mtl >=2.2.1 && <3, free >=4.12.3 && <5.1, semigroups >=0.18.1 && <1, profunctors >=5.2 && <6, transformers >=0.5.0.0 && <1
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
This also removes a bad build plan on GHC 7.8, but we could add a dependency on `void` instead and continue to support 7.8